### PR TITLE
Initial SaveState system, SceneData, SaveMe, IRuntimeSerialized

### DIFF
--- a/Assets/Prefabs/Player.prefab
+++ b/Assets/Prefabs/Player.prefab
@@ -338,7 +338,7 @@ GameObject:
   - component: {fileID: 2545709257122875069}
   - component: {fileID: 2545709257122875040}
   - component: {fileID: 2545709257122875041}
-  - component: {fileID: 4021843959973660922}
+  - component: {fileID: 231650465261193435}
   m_Layer: 0
   m_Name: Player
   m_TagString: Player
@@ -454,11 +454,11 @@ MonoBehaviour:
   focalDistance: 8
   bobbingIntensity: 0.01
   bobbingSpeed: 12
-  bobbingIntensitySprinting: 0.0146
+  bobbingIntensitySprinting: 0.0776
   bobbingSpeedSprinting: 18
   bobbingIntensityCrouching: 0.0118
   bobbingSpeedCrouching: 8
---- !u!114 &4021843959973660922
+--- !u!114 &231650465261193435
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -467,11 +467,8 @@ MonoBehaviour:
   m_GameObject: {fileID: 2545709257122875071}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 7542d63496deb4a439bbed2b6d99752d, type: 3}
+  m_Script: {fileID: 11500000, guid: edbf17894347cd2468d0e541ee8b91d1, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  velocity: {x: 0, y: 0, z: 0}
-  xRot: 0
-  yRot: 0
-  playerState: 0
-  isOnGround: 0
+  cam: {fileID: 2545709256136786215}
+  playerActivateDistance: 3.5

--- a/Assets/Prefabs/Player.prefab
+++ b/Assets/Prefabs/Player.prefab
@@ -454,7 +454,7 @@ MonoBehaviour:
   focalDistance: 8
   bobbingIntensity: 0.01
   bobbingSpeed: 12
-  bobbingIntensitySprinting: 0.0776
+  bobbingIntensitySprinting: 0.0158
   bobbingSpeedSprinting: 18
   bobbingIntensityCrouching: 0.0118
   bobbingSpeedCrouching: 8

--- a/Assets/Prefabs/Player.prefab
+++ b/Assets/Prefabs/Player.prefab
@@ -340,7 +340,7 @@ GameObject:
   - component: {fileID: 2545709257122875041}
   m_Layer: 0
   m_Name: Player
-  m_TagString: Untagged
+  m_TagString: Player
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0

--- a/Assets/Prefabs/Player.prefab
+++ b/Assets/Prefabs/Player.prefab
@@ -338,6 +338,7 @@ GameObject:
   - component: {fileID: 2545709257122875069}
   - component: {fileID: 2545709257122875040}
   - component: {fileID: 2545709257122875041}
+  - component: {fileID: 4021843959973660922}
   m_Layer: 0
   m_Name: Player
   m_TagString: Player
@@ -457,3 +458,20 @@ MonoBehaviour:
   bobbingSpeedSprinting: 18
   bobbingIntensityCrouching: 0.0118
   bobbingSpeedCrouching: 8
+--- !u!114 &4021843959973660922
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2545709257122875071}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7542d63496deb4a439bbed2b6d99752d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  velocity: {x: 0, y: 0, z: 0}
+  xRot: 0
+  yRot: 0
+  playerState: 0
+  isOnGround: 0

--- a/Assets/Scripts/Core/GameManager.cs
+++ b/Assets/Scripts/Core/GameManager.cs
@@ -7,6 +7,14 @@ using UnityEngine;
 public class GameManager {
     public static readonly GameManager instance = new GameManager();
 
+    public SaveState saveState;
     public GameEvents events = new GameEvents();
     public GameOptions gameOptions = new GameOptions();
+
+    public void LoadOrCreateSave(int slot) {
+        // Failsafe in case we're loading a new save while already in a save.
+        if (saveState != null) saveState.SaveCurrent();
+        saveState = new SaveState(slot);
+        saveState.Load();
+    }
 }

--- a/Assets/Scripts/Editor.meta
+++ b/Assets/Scripts/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ab1ab0e8e02888f46b545b2b428f7668
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Editor/ReadOnlyPropertyDrawer.cs
+++ b/Assets/Scripts/Editor/ReadOnlyPropertyDrawer.cs
@@ -1,0 +1,11 @@
+using UnityEngine;
+using UnityEditor;
+
+[CustomPropertyDrawer(typeof(ReadOnlyPropertyAttribute))]
+public class ReadOnlyPropertyDrawer : PropertyDrawer {
+    public override void OnGUI(Rect position, SerializedProperty property, GUIContent label) {
+        GUI.enabled = false;
+        EditorGUI.PropertyField(position, property, label, true);
+        GUI.enabled = true;
+    }
+}

--- a/Assets/Scripts/Editor/ReadOnlyPropertyDrawer.cs.meta
+++ b/Assets/Scripts/Editor/ReadOnlyPropertyDrawer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0e8f074f0c0793047a4706839118b2be
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Editor/SaveMeEditor.cs
+++ b/Assets/Scripts/Editor/SaveMeEditor.cs
@@ -7,11 +7,16 @@ using UnityEditor;
 [CustomEditor(typeof(SaveMe))]
 public class SaveMeEditor : Editor {
     public override void OnInspectorGUI() {
-        DrawDefaultInspector();
         // Button to reassign identifier
         SaveMe saveMe = (SaveMe) target;
         if (GUILayout.Button("Reassign UID")) {
+            // Remove old UID from the global map if it is mapped to this object
+            if (SaveMe.uidMap.ContainsKey(saveMe.identifier) && SaveMe.uidMap[saveMe.identifier] == saveMe) {
+                SaveMe.uidMap.Remove(saveMe.identifier);
+            }
+            // SaveMe will pick a new UID next frame
             saveMe.identifier = null;
         }
+        DrawDefaultInspector();
     }
 }

--- a/Assets/Scripts/Editor/SaveMeEditor.cs
+++ b/Assets/Scripts/Editor/SaveMeEditor.cs
@@ -1,0 +1,17 @@
+using UnityEngine;
+using UnityEditor;
+
+/// <summary>
+/// A custom Inspector display for the SaveMe component adding a button to reassign the UID for testing purposes.
+/// </summary>
+[CustomEditor(typeof(SaveMe))]
+public class SaveMeEditor : Editor {
+    public override void OnInspectorGUI() {
+        DrawDefaultInspector();
+        // Button to reassign identifier
+        SaveMe saveMe = (SaveMe) target;
+        if (GUILayout.Button("Reassign UID")) {
+            saveMe.identifier = null;
+        }
+    }
+}

--- a/Assets/Scripts/Editor/SaveMeEditor.cs.meta
+++ b/Assets/Scripts/Editor/SaveMeEditor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5cbbb4311ae9dfe4492749392ce8f0b5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Persistence.meta
+++ b/Assets/Scripts/Persistence.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: dbf252e90836ab342872bc4413b56252
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Persistence/IRuntimeSerialized.cs
+++ b/Assets/Scripts/Persistence/IRuntimeSerialized.cs
@@ -1,0 +1,1 @@
+public interface IRuntimeSerialized {}

--- a/Assets/Scripts/Persistence/IRuntimeSerialized.cs.meta
+++ b/Assets/Scripts/Persistence/IRuntimeSerialized.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4dc7c1194fd52864991c8a3ceb3735d2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Persistence/SaveMe.cs
+++ b/Assets/Scripts/Persistence/SaveMe.cs
@@ -1,0 +1,106 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+#if UNITY_EDITOR
+using UnityEditor;
+using UnityEditor.SceneManagement;
+#endif
+
+/// <summary>
+/// Component that defines which parts of a GameObject to serialize.
+/// The component assigns a persistent UID to the object in the editor that is used at runtime.
+/// UID code based on an answer by dishmop: https://answers.unity.com/questions/1249093/need-a-persistent-unique-id-for-gameobjects.html
+/// </summary>
+[ExecuteAlways]
+[Serializable]
+public class SaveMe : MonoBehaviour, ISerializationCallbackReceiver {
+    static Dictionary<string, SaveMe> uidMap = new Dictionary<string, SaveMe>();
+
+    [ReadOnlyProperty]
+    public string identifier;
+
+    public bool savePosition = true;
+    public bool saveRotation = true;
+    public bool saveScale = false;
+    public bool saveRigidbodyForces = false;
+    public MonoBehaviour[] saveComponents;
+
+    // Required to access from serialization callbacks
+    new private Transform transform;
+    [SerializeField] [HideInInspector]
+    private Vector3 _pos;
+    [SerializeField] [HideInInspector]
+    private Vector3 _rot;
+    [SerializeField] [HideInInspector]
+    private Vector3 _scale;
+    [SerializeField] [HideInInspector]
+    private Vector3 _rbForce;
+    [SerializeField] [HideInInspector]
+    private string[] _componentData;
+
+    #if !UNITY_EDITOR
+
+    public void OnBeforeSerialize() {
+        // Can't call this in Start or we lose the reference later
+        transform = GetComponent<Transform>();
+
+        // Serialize default fields
+        if (savePosition) _pos = transform.position;
+        if (saveRotation) _rot = transform.localRotation.eulerAngles;
+        if (saveScale) _scale = transform.localScale;
+        if (saveRigidbodyForces) _rbForce = GetComponent<Rigidbody>()?.velocity ?? Vector3.zero;
+
+        // Serialize extra component data
+        _componentData = new string[saveComponents.Length];
+        for (int i = 0; i < saveComponents.Length; i++) {
+            if (saveComponents[i] == null) continue;
+            _componentData[i] = JsonUtility.ToJson(saveComponents[i]);
+        }
+    }
+
+    public void OnAfterDeserialize() {
+        // Can't call this in Start or we lose the reference later
+        transform = GetComponent<Transform>();
+
+        // Deserialize default fields
+        if (savePosition) transform.position = _pos;
+        if (saveRotation) transform.localRotation = Quaternion.Euler(_rot);
+        if (saveScale) transform.localScale = _scale;
+        if (saveRigidbodyForces) GetComponent<Rigidbody>().velocity = _rbForce;
+
+        // Deserialize extra component data
+        for (int i = 0; i < saveComponents.Length; i++) {
+            if (saveComponents[i] == null || _componentData[i] == null) continue;
+            JsonUtility.FromJsonOverwrite(_componentData[i], saveComponents[i]);
+        }
+    }
+    #endif
+
+    // Only assign a UID in the editor build
+    #if UNITY_EDITOR
+    void Update() {
+        // If the object is a prefab (not in a scene), or the game is running, don't assign a UID
+        if (Application.IsPlaying(gameObject) || gameObject.scene.name == null) return;
+        // If the identifier has not been assigned or it's a duplicate (or otherwise invalid), pick a new one
+        if (identifier == null || identifier == "" || (uidMap.ContainsKey(identifier) && uidMap[identifier] != this) || !identifier.StartsWith(gameObject.scene.name)) {
+            identifier = gameObject.scene.name + "_" + Guid.NewGuid();
+            if (!uidMap.ContainsKey(identifier)) {
+                // If adding the new UID is successful
+                uidMap.Add(identifier, this);
+                EditorUtility.SetDirty(this);
+                EditorSceneManager.MarkSceneDirty(gameObject.scene);
+            }
+        }
+    }
+
+    void OnDestroy() {
+        // Remove the UID from the map when the object is destroyed
+        if (!Application.IsPlaying(gameObject) && identifier != null) uidMap.Remove(identifier, out _);
+    }
+
+    // Need empty definitions for these in the editor to avoid errors
+    public void OnBeforeSerialize() {}
+    public void OnAfterDeserialize() {}
+#endif
+}

--- a/Assets/Scripts/Persistence/SaveMe.cs.meta
+++ b/Assets/Scripts/Persistence/SaveMe.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5864a21b6dde2ec45a66373a55a78763
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Persistence/SaveState.cs
+++ b/Assets/Scripts/Persistence/SaveState.cs
@@ -1,4 +1,6 @@
+using Microsoft.VisualBasic;
 using System.IO;
+using System.Text.RegularExpressions;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 
@@ -7,7 +9,12 @@ using UnityEngine.SceneManagement;
 /// </summary>
 public class SaveState {
     private const int startScene = 1;
-    private readonly int slot;
+
+    public readonly int slot;
+    public string lastSceneName;
+    public string lastSaveDate;
+    public string lastSaveTime;
+
     private SceneData currentScene;
     private string playerData;
     private string spawnPoint;
@@ -18,6 +25,7 @@ public class SaveState {
     /// <param name="slot"></param>
     public SaveState(int slot) {
         this.slot = slot;
+        ReadSceneInfo();
     }
 
     /// <summary>
@@ -33,7 +41,7 @@ public class SaveState {
     /// <summary>
     /// Loads the given scene by path or build index, serializing the active one and deserializing the new one.
     /// </summary>
-    public void LoadScene(string scenePath = null, int sceneIndex = -1, string spawnPoint = null) {
+    internal void LoadScene(string scenePath = null, int sceneIndex = -1, string spawnPoint = null) {
         // If another game scene is loaded (not the menu), write it to disk first
         playerData = null;
         this.spawnPoint = spawnPoint;
@@ -44,6 +52,7 @@ public class SaveState {
                 Directory.CreateDirectory(Path());
                 playerData = JsonUtility.ToJson(player.playerData);
                 File.WriteAllText(Path() + "/player.dat", playerData);
+                WriteSceneInfo();
             }
         }
 
@@ -56,29 +65,48 @@ public class SaveState {
     /// We need to listen for the new scene being loaded separately because SceneManager#LoadScene queues the new scene to load in the following frame.
     /// We can't just use Update because this class isn't a MonoBehaviour.
     /// </summary>
-    public void OnSceneLoaded(Scene old, Scene current) {
+    internal void OnSceneLoaded(Scene old, Scene current) {
         // Set up the newly loaded scene
         currentScene = SceneData.Get(SceneManager.GetActiveScene());
         if (currentScene == null) return; // Edge case in case we caught a scene load before SaveState#Load was called
         currentScene.Read(Path());
         currentScene.SpawnPlayer(playerData, spawnPoint);
-
-        // Save the now-current scene index to disk
-        Directory.CreateDirectory(Path());
-        File.WriteAllText(Path() + "/scene.dat", SceneManager.GetActiveScene().buildIndex.ToString());
-
         playerData = spawnPoint = null;
     }
 
     /// <summary>
     /// Called to serialize the current scene without loading another one; ie when the application is closed without switching scenes first.
     /// </summary>
-    public void SaveCurrent() {
+    internal void SaveCurrent() {
+        Directory.CreateDirectory(Path());
         if (currentScene != null) currentScene.Write(Path());
         var player = GameObject.FindObjectOfType<PlayerMovement>();
+        if (player != null) {
+            File.WriteAllText(Path() + "/player.dat", JsonUtility.ToJson(player.playerData));
+            WriteSceneInfo();
+        }
+    }
+
+    private void WriteSceneInfo() {
         Directory.CreateDirectory(Path());
-        if (player != null) File.WriteAllText(Path() + "/player.dat", JsonUtility.ToJson(player.playerData));
         File.WriteAllText(Path() + "/scene.dat", SceneManager.GetActiveScene().buildIndex.ToString());
+        lastSceneName = Regex.Replace(SceneManager.GetActiveScene().name, @"(\B[A-Z]+?(?=[A-Z][^A-Z])|\B[A-Z]+?(?=[^A-Z]))", " $1");
+        lastSaveDate = System.DateTime.Now.ToString("yyyy-MM-dd");
+        lastSaveTime = System.DateTime.Now.ToString("HH:mm:ss");
+        File.WriteAllLines(Path() + "/info.dat", new string[] { lastSceneName, lastSaveDate, lastSaveTime });
+    }
+
+    private void ReadSceneInfo() {
+        if (File.Exists(Path() + "/info.dat")) {
+            var lines = File.ReadAllLines(Path() + "/info.dat");
+            lastSceneName = lines[0];
+            lastSaveDate = lines[1];
+            lastSaveTime = lines[2];
+        }
+    }
+
+    public bool Exists() {
+        return lastSaveDate != null && lastSaveTime != null;
     }
 
     /// <summary>

--- a/Assets/Scripts/Persistence/SaveState.cs
+++ b/Assets/Scripts/Persistence/SaveState.cs
@@ -1,0 +1,67 @@
+using System.IO;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+
+/// <summary>
+/// Handles serialization and deserialization of SceneData and other objects independent of a loaded scene.
+/// </summary>
+public class SaveState {
+    private const int startScene = 0;
+    private int slot;
+    private SceneData currentScene;
+
+    /// <summary>
+    /// Constructs a new SaveState instance for the given slot.
+    /// </summary>
+    /// <param name="slot"></param>
+    public SaveState(int slot) {
+        this.slot = slot;
+    }
+
+    /// <summary>
+    /// Fetch the save state if it exists and load the last scene, otherwise start from scratch.
+    /// </summary>
+    public void Load() {
+        if (File.Exists(Path() + "/scene.dat")) LoadScene(sceneIndex: int.Parse(File.ReadAllText(Path() + "/scene.dat")));
+        else LoadScene(sceneIndex: startScene);
+    }
+
+    /// <summary>
+    /// Loads the given scene by path or build index, serializing the active one and deserializing the new one.
+    /// </summary>
+    public void LoadScene(string scenePath = null, int sceneIndex = -1, string spawnPoint = null) {
+        // If another game scene is loaded (not the menu), write it to disk first
+        string playerData = null;
+        if (currentScene != null) {
+            currentScene.Write(Path());
+            // Idiotproof player data serialization
+            var player = GameObject.FindGameObjectWithTag("Player");
+            if (player != null) playerData = JsonUtility.ToJson(player);
+        }
+        // If a scene path is given, load it by path; otherwise load it by index
+        if (scenePath != null) SceneManager.LoadScene(scenePath);
+        else SceneManager.LoadScene(sceneIndex);
+        File.WriteAllText(Path() + "/scene.dat", SceneManager.GetActiveScene().buildIndex.ToString());
+        // Set up the newly loaded scene
+        currentScene = SceneData.Get(SceneManager.GetActiveScene());
+        currentScene.Read(Path());
+        currentScene.SpawnPlayer(playerData, spawnPoint);
+    }
+
+    /// <summary>
+    /// Called to serialize the current scene without loading another one; ie when the application is closed without switching scenes first.
+    /// </summary>
+    public void SaveCurrent() {
+        if (currentScene != null) currentScene.Write(Path());
+        var player = GameObject.FindGameObjectWithTag("Player");
+        if (player != null) File.WriteAllText(Path() + "/player.dat", JsonUtility.ToJson(player));
+        File.WriteAllText(Path() + "/scene.dat", SceneManager.GetActiveScene().buildIndex.ToString());
+    }
+
+    /// <summary>
+    /// Gets the path for this save.
+    /// </summary>
+    public string Path() {
+        return Application.persistentDataPath + "saves/" + slot;
+    }
+}

--- a/Assets/Scripts/Persistence/SaveState.cs
+++ b/Assets/Scripts/Persistence/SaveState.cs
@@ -29,10 +29,27 @@ public class SaveState {
     }
 
     /// <summary>
+        /// Clear all this save state's data and erases its directory.
+    /// </summary>
+    public void Clear() {
+        if (Directory.Exists(Path())) Directory.Delete(Path(), true);
+        currentScene = null;
+        playerData = null;
+        spawnPoint = null;
+    }
+
+    /// <summary>
     /// Fetch the save state if it exists and load the last scene, otherwise start from scratch.
     /// </summary>
     public void Load() {
+        // Add event listeners
         SceneManager.activeSceneChanged += OnSceneLoaded;
+        Application.wantsToQuit += () => {
+            SaveCurrent();
+            return true;
+        };
+
+        // Load basic info and player data
         playerData = File.Exists(Path() + "/player.dat") ? File.ReadAllText(Path() + "/player.dat") : null;
         if (File.Exists(Path() + "/scene.dat")) LoadScene(sceneIndex: int.Parse(File.ReadAllText(Path() + "/scene.dat")));
         else LoadScene(sceneIndex: startScene);

--- a/Assets/Scripts/Persistence/SaveState.cs.meta
+++ b/Assets/Scripts/Persistence/SaveState.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e78020df369389e4386cab3bd1e80503
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Persistence/SceneData.cs
+++ b/Assets/Scripts/Persistence/SceneData.cs
@@ -1,0 +1,98 @@
+using System.Linq;
+using System;
+using System.IO;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+
+/// <summary>
+/// Handles serialization and deserialization within a loaded scene.
+/// </summary>
+public class SceneData : MonoBehaviour {
+    public string defaultSpawnPoint;
+    public Dictionary<string, GameObject> saveData;
+
+    /// <summary>
+    /// Gets the SceneData instance from a given Scene. One is expected to exist in any loaded scene.
+    /// </summary>
+    public static SceneData Get(Scene scene) {
+        return scene.GetRootGameObjects().First(obj => obj.GetComponent<SceneData>() != null).GetComponent<SceneData>();
+    }
+
+    void Awake() {
+        // In Awake, we define which objects we want to track in the scene; these objects
+        // can be either defined manually in the inspector or dynamically if they have the SaveData tag
+        if (saveData == null) saveData = new Dictionary<string, GameObject>();
+        foreach (GameObject obj in GameObject.FindGameObjectsWithTag("SaveData")) {
+            saveData.Add(Identifier(obj), obj);
+        }
+    }
+
+    /// <summary>
+    /// Loads any saved player data and sets the player's position to the correct spawn point, if provided.
+    /// </summary>
+    public void SpawnPlayer(string playerData = null, string spawnPoint = null) {
+        if (spawnPoint == null) spawnPoint = defaultSpawnPoint;
+        GameObject player = GameObject.FindGameObjectWithTag("Player");
+        GameObject spawnObj = GameObject.FindGameObjectsWithTag("SpawnPoint").First(obj => obj.name == spawnPoint);
+        if (playerData != null) JsonUtility.FromJsonOverwrite(playerData, player);
+        player.transform.position = spawnObj.transform.position;
+    }
+
+    /// <summary>
+    /// Writes this scene's data to disk.
+    /// </summary>
+    /// <param name="root">The save slot's root path, as returned by SaveState#Path</param>
+    public void Write(string root) {
+        List<string> removed = new List<string>();
+        foreach (var (id, obj) in saveData) {
+            // If the object has been destroyed, add it to the list of removed objects; otherwise serialize it
+            if (obj != null) {
+                string path = root + "/" + Path() + "/" + id + ".dat";
+                // TODO: More selective save data; possibly a SaveMe component?
+                File.WriteAllText(path, JsonUtility.ToJson(obj));
+            } else {
+                removed.Add(id);
+            }
+        }
+        // Write a list of removed objects to disk to avoid deserializing them
+        File.WriteAllLines(root + "/" + gameObject.scene.path + "/removed.dat", removed);
+    }
+
+    /// <summary>
+    /// Reads this scene's data from disk.
+    /// </summary>
+    /// <param name="root">The save slot's root path, as returned by SaveState#Path</param>
+    public void Read(string root) {
+        // If the removed file doesn't exist, the scene hasn't been serialized yet - we can stick to defaults
+        if (!File.Exists(root + "/" + gameObject.scene.path + "/removed.dat")) return;
+        // Read the list of removed objects from disk
+        string[] removed = File.ReadAllLines(root + "/" + gameObject.scene.path + "/removed.dat");
+        foreach (var (id, obj) in saveData) {
+            // If the object was destroyed before serialization, destroy it again now
+            if (!removed.Contains(id)) {
+                string path = root + "/" + gameObject.scene.path + "/" + id + ".dat";
+                if (File.Exists(path)) {
+                    JsonUtility.FromJsonOverwrite(File.ReadAllText(path), obj);
+                }
+            } else {
+                Destroy(obj);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Gets the path of the scene this SceneData is attached to.
+    /// </summary>
+    public string Path() {
+        return gameObject.scene.path;
+    }
+
+    /// <summary>
+    /// Determines an identifier for the given game object.
+    /// </summary>
+    string Identifier(GameObject gameObject) {
+        throw new System.NotImplementedException();
+    }
+
+}

--- a/Assets/Scripts/Persistence/SceneData.cs.meta
+++ b/Assets/Scripts/Persistence/SceneData.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ba9056a8785420e4d995b2bbbb5fd732
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Persistence/readme.md
+++ b/Assets/Scripts/Persistence/readme.md
@@ -4,7 +4,9 @@ This directory contains the game save/loading system. Tentative implementation p
 
 ## SaveMe
 - If you're a designer, this is the one you'll need to worry about
-- Add it to any object for that object to save and load any contained data
+- Add it to any object to save and load specific data
+- Can save transform values and rigidbody velocity by default
+- Other components attached to the same object will be saved if they have the `IRuntimeSerialized` marker interface
 - Takes care of assigning a persistent UID in the editor build, which is used at runtime
 ## SceneData
 - Component attached to one object in each scene

--- a/Assets/Scripts/Persistence/readme.md
+++ b/Assets/Scripts/Persistence/readme.md
@@ -2,6 +2,15 @@
 
 This directory contains the game save/loading system. Tentative implementation plan is as below:
 
+## SaveMe
+- If you're a designer, this is the one you'll need to worry about
+- Add it to any object for that object to save and load any contained data
+- Takes care of assigning a persistent UID in the editor build, which is used at runtime
+## SceneData
+- Component attached to one object in each scene
+- Defines which data needs to be serialized within the scene
+- Maps game objects by unique identifiers
+- Stores a list of game obejcts that have been destroyed to destroy again if the scene is deserialized
 ## SaveState
 - Object instance under GameManager, created at startup for the selected save slot
 - Stores the actual current game's save state for a given slot
@@ -9,9 +18,3 @@ This directory contains the game save/loading system. Tentative implementation p
 - When a scene is loaded, writes the last one to disk and sets up the now active SceneData for serialization; if data exists on the disk for this save slot it loads that to the SceneData object
 - Stores a reference to only one active SceneData object at a time
 - Contains a `LoadScene` method that must be used in place of `SceneManager#LoadScene`
-
-## SceneData
-- Component attached to one object in each scene
-- Defines which data needs to be serialized within the scene
-- Maps game objects by unique identifiers
-- Stores a list of game obejcts that have been destroyed to destroy again if the scene is deserialized

--- a/Assets/Scripts/Persistence/readme.md
+++ b/Assets/Scripts/Persistence/readme.md
@@ -1,0 +1,17 @@
+# SaveState system
+
+This directory contains the game save/loading system. Tentative implementation plan is as below:
+
+## SaveState
+- Object instance under GameManager, created at startup for the selected save slot
+- Stores the actual current game's save state for a given slot
+- Holds any non-scene-attached data between scenes (inventory, etc)
+- When a scene is loaded, writes the last one to disk and sets up the now active SceneData for serialization; if data exists on the disk for this save slot it loads that to the SceneData object
+- Stores a reference to only one active SceneData object at a time
+- Contains a `LoadScene` method that must be used in place of `SceneManager#LoadScene`
+
+## SceneData
+- Component attached to one object in each scene
+- Defines which data needs to be serialized within the scene
+- Maps game objects by unique identifiers
+- Stores a list of game obejcts that have been destroyed to destroy again if the scene is deserialized

--- a/Assets/Scripts/Persistence/readme.md.meta
+++ b/Assets/Scripts/Persistence/readme.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 70e22f0c7b7d2a842bf8979df5ecf405
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Player/PlayerData.cs
+++ b/Assets/Scripts/Player/PlayerData.cs
@@ -1,0 +1,35 @@
+using System;
+using UnityEngine;
+
+/// <summary>
+/// Defines data for the player to be serialized and passed between scenes.
+/// Separate from PlayerMovement to avoid passing references back and forth.
+/// </summary>
+[Serializable]
+public class PlayerData : MonoBehaviour, ISerializationCallbackReceiver {
+    public Vector3 velocity;
+    public float xRot;
+    public float yRot;
+    public PlayerMovement.PlayerState playerState;
+    public bool isOnGround;
+
+    private PlayerMovement playerMovement;
+
+    public void OnBeforeSerialize() {
+        playerMovement = GetComponent<PlayerMovement>();
+        velocity = playerMovement.velocity;
+        xRot = playerMovement.xRot;
+        yRot = playerMovement.yRot;
+        playerState = playerMovement.playerState;
+        isOnGround = playerMovement.isOnGround;
+    }
+
+    public void OnAfterDeserialize() {
+        playerMovement = GetComponent<PlayerMovement>();
+        playerMovement.velocity = velocity;
+        playerMovement.xRot = xRot;
+        playerMovement.yRot = yRot;
+        playerMovement.playerState = playerState;
+        playerMovement.isOnGround = isOnGround;
+    }
+}

--- a/Assets/Scripts/Player/PlayerData.cs
+++ b/Assets/Scripts/Player/PlayerData.cs
@@ -6,30 +6,10 @@ using UnityEngine;
 /// Separate from PlayerMovement to avoid passing references back and forth.
 /// </summary>
 [Serializable]
-public class PlayerData : MonoBehaviour, ISerializationCallbackReceiver {
+public struct PlayerData {
     public Vector3 velocity;
     public float xRot;
     public float yRot;
     public PlayerMovement.PlayerState playerState;
     public bool isOnGround;
-
-    private PlayerMovement playerMovement;
-
-    public void OnBeforeSerialize() {
-        playerMovement = GetComponent<PlayerMovement>();
-        velocity = playerMovement.velocity;
-        xRot = playerMovement.xRot;
-        yRot = playerMovement.yRot;
-        playerState = playerMovement.playerState;
-        isOnGround = playerMovement.isOnGround;
-    }
-
-    public void OnAfterDeserialize() {
-        playerMovement = GetComponent<PlayerMovement>();
-        playerMovement.velocity = velocity;
-        playerMovement.xRot = xRot;
-        playerMovement.yRot = yRot;
-        playerMovement.playerState = playerState;
-        playerMovement.isOnGround = isOnGround;
-    }
 }

--- a/Assets/Scripts/Player/PlayerData.cs.meta
+++ b/Assets/Scripts/Player/PlayerData.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7542d63496deb4a439bbed2b6d99752d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Player/PlayerMovement.cs
+++ b/Assets/Scripts/Player/PlayerMovement.cs
@@ -51,17 +51,17 @@ public class PlayerMovement : MonoBehaviour {
     [Tooltip("View bobbing speed when crouching")]
     public float bobbingSpeedCrouching;
 
-    private GameOptions gameOptions;
-    private CharacterController controller;
-    private Vector3 cameraFocus;
-    private Vector3 initialScale;
-    private Vector3 initialPlayerLook;
-    private Vector3 velocity = Vector3.zero;
-    private float xRot = 0;
-    private float yRot = 0;
-    private PlayerState playerState = PlayerState.Normal;
-    private float groundDistance;
-    private bool isOnGround = true;
+    internal GameOptions gameOptions;
+    internal CharacterController controller;
+    internal Vector3 cameraFocus;
+    internal Vector3 initialScale;
+    internal Vector3 initialPlayerLook;
+    internal Vector3 velocity = Vector3.zero;
+    internal float xRot = 0;
+    internal float yRot = 0;
+    internal PlayerState playerState = PlayerState.Normal;
+    internal float groundDistance;
+    internal bool isOnGround = true;
 
     void Start() {
         gameOptions = GameManager.instance.gameOptions;

--- a/Assets/Scripts/Player/PlayerMovement.cs
+++ b/Assets/Scripts/Player/PlayerMovement.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
@@ -51,17 +52,16 @@ public class PlayerMovement : MonoBehaviour {
     [Tooltip("View bobbing speed when crouching")]
     public float bobbingSpeedCrouching;
 
-    internal GameOptions gameOptions;
-    internal CharacterController controller;
-    internal Vector3 cameraFocus;
-    internal Vector3 initialScale;
-    internal Vector3 initialPlayerLook;
-    internal Vector3 velocity = Vector3.zero;
-    internal float xRot = 0;
-    internal float yRot = 0;
-    internal PlayerState playerState = PlayerState.Normal;
-    internal float groundDistance;
-    internal bool isOnGround = true;
+    // Serialized separately by SceneData to avoid overwriting inspector references at runtime
+    [NonSerialized]
+    public PlayerData playerData;
+
+    private GameOptions gameOptions;
+    private CharacterController controller;
+    private Vector3 cameraFocus;
+    private Vector3 initialScale;
+    private Vector3 initialPlayerLook;
+    private float groundDistance;
 
     void Start() {
         gameOptions = GameManager.instance.gameOptions;
@@ -76,24 +76,24 @@ public class PlayerMovement : MonoBehaviour {
     void FixedUpdate() {
         // Calculate movement in FixedUpdate, per physics tick
         // First, check if we're on the ground
-        isOnGround = Physics.Raycast(transform.position, Vector3.down, groundDistance * transform.localScale.y + .1f);
+        playerData.isOnGround = Physics.Raycast(transform.position, Vector3.down, groundDistance * transform.localScale.y + .1f);
 
         // Check if sprinting/crouching
         // TODO: Stamina
-        bool canSprint = isOnGround;
+        bool canSprint = playerData.isOnGround;
         if (Input.GetKey(gameOptions.crouch.Value)) {
-            playerState = PlayerState.Crouching;
+            playerData.playerState = PlayerState.Crouching;
         } else {
-            if (canSprint && Input.GetKey(gameOptions.sprint.Value)) playerState = PlayerState.Sprinting;
-            else playerState = PlayerState.Normal;
+            if (canSprint && Input.GetKey(gameOptions.sprint.Value)) playerData.playerState = PlayerState.Sprinting;
+            else playerData.playerState = PlayerState.Normal;
         }
 
         // Add player movement velocity
         Vector3 horizontalVelocity = (GetInputVector() * MoveSpeed() / 50);
-        velocity.Set(horizontalVelocity.x, velocity.y, horizontalVelocity.z);
+        playerData.velocity.Set(horizontalVelocity.x, playerData.velocity.y, horizontalVelocity.z);
 
         // Crouching
-        float targetHeight = playerState == PlayerState.Crouching ? crouchHeight : initialScale.y;
+        float targetHeight = playerData.playerState == PlayerState.Crouching ? crouchHeight : initialScale.y;
         if (transform.localScale.y != targetHeight) {
             float deltaHeight = (transform.localScale.y - targetHeight) * (crouchSmoothing - 1);
             transform.localScale = new Vector3(transform.localScale.x, transform.localScale.y + deltaHeight, transform.localScale.z);
@@ -101,30 +101,30 @@ public class PlayerMovement : MonoBehaviour {
         }
 
         // Jumping
-        if (gameOptions.jump.GetKey() && isOnGround) {
-            isOnGround = false;
-            velocity.y = jumpSpeed / 50;
+        if (gameOptions.jump.GetKey() && playerData.isOnGround) {
+            playerData.isOnGround = false;
+            playerData.velocity.y = jumpSpeed / 50;
         }
         
         // Gravity
-        velocity.y -= fallSpeed / 50;
-        controller.Move(velocity);
+        playerData.velocity.y -= fallSpeed / 50;
+        controller.Move(playerData.velocity);
 
         // Calculate rotation from mouse movement
         float mouseX = Input.GetAxis("Mouse X") * Time.deltaTime * mouseSensitivity * gameOptions.mouseSensitivity.Value;
         float mouseY = Input.GetAxis("Mouse Y") * Time.deltaTime * mouseSensitivity * gameOptions.mouseSensitivity.Value;
-        yRot += mouseX;
-        xRot = Mathf.Clamp(xRot - mouseY, -88, 88);
+        playerData.yRot += mouseX;
+        playerData.xRot = Mathf.Clamp(playerData.xRot - mouseY, -88, 88);
 
         // Rotate the player along only the horizontal axis
-        transform.rotation = Quaternion.Euler(0, yRot, 0);
+        transform.rotation = Quaternion.Euler(0, playerData.yRot, 0);
 
         // Rotate the player's look vector along both axes (the camera inherits this transformation)
-        playerLook.rotation = Quaternion.Euler(xRot, yRot, 0);
+        playerLook.rotation = Quaternion.Euler(playerData.xRot, playerData.yRot, 0);
         
         // Apply view bobbing if the player is moving horizontally
-        if (isOnGround && horizontalVelocity.magnitude > 0) {
-            Vector3 viewBobbing = playerState switch {
+        if (playerData.isOnGround && horizontalVelocity.magnitude > 0) {
+            Vector3 viewBobbing = playerData.playerState switch {
                 PlayerState.Crouching => ViewBobbing(bobbingSpeedCrouching, bobbingIntensityCrouching),
                 PlayerState.Sprinting => ViewBobbing(bobbingSpeedSprinting, bobbingIntensitySprinting),
                 _ => ViewBobbing(bobbingSpeed, bobbingIntensity)
@@ -173,13 +173,14 @@ public class PlayerMovement : MonoBehaviour {
     }
 
     private float MoveSpeed() {
-        return moveSpeed * playerState switch {
+        return moveSpeed * playerData.playerState switch {
             PlayerState.Crouching => crouchModifier,
             PlayerState.Sprinting => sprintModifier,
             _ => 1
         };
     }
 
+    [Serializable]
     public enum PlayerState {
         Normal, Crouching, Sprinting
     }

--- a/Assets/Scripts/Player/SceneSwitch.cs
+++ b/Assets/Scripts/Player/SceneSwitch.cs
@@ -1,0 +1,22 @@
+using UnityEngine;
+using UnityEngine.SceneManagement;
+
+/// <summary>
+/// Component for trigger objects to switch to another scene.
+/// </summary>
+[RequireComponent(typeof(Collider))]
+public class SceneSwitch : MonoBehaviour {
+
+    [Tooltip("The scene to switch to.")]
+    public SceneReference scene;
+    [Tooltip("An ID for a spawn point in the scene being switched to. Must match an ID under a SpawnPoint component in the scene.")]
+    public string spawnPoint;
+
+    void OnTriggerEnter(Collider other) {
+        if (other.gameObject.tag == "Player") {
+            // Switch to the specified scene, alerting SceneData of the spawn point to use.
+            GameManager.instance.saveState.LoadScene(scenePath: scene.ScenePath, spawnPoint: spawnPoint);
+        }
+    }
+
+}

--- a/Assets/Scripts/Player/SceneSwitch.cs
+++ b/Assets/Scripts/Player/SceneSwitch.cs
@@ -4,17 +4,17 @@ using UnityEngine.SceneManagement;
 /// <summary>
 /// Component for trigger objects to switch to another scene.
 /// </summary>
-[RequireComponent(typeof(Collider))]
-public class SceneSwitch : MonoBehaviour {
+public class SceneSwitch : Interactible {
 
     [Tooltip("The scene to switch to.")]
     public SceneReference scene;
     [Tooltip("An ID for a spawn point in the scene being switched to. Must match an ID under a SpawnPoint component in the scene.")]
     public string spawnPoint;
 
-    void OnTriggerEnter(Collider other) {
-        if (other.gameObject.tag == "Player") {
-            // Switch to the specified scene, alerting SceneData of the spawn point to use.
+    public override void Interact() {
+        // If the current scene setup is done
+        if (SceneData.Get(gameObject.scene).Ready()) {
+            // Switch to the specified scene, alerting SceneData of the spawn point to use
             GameManager.instance.saveState.LoadScene(scenePath: scene.ScenePath, spawnPoint: spawnPoint);
         }
     }

--- a/Assets/Scripts/Player/SceneSwitch.cs.meta
+++ b/Assets/Scripts/Player/SceneSwitch.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c1e0c1a0316ee3146bf5e69048f7f874
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Property.meta
+++ b/Assets/Scripts/Property.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: fd71ff15164dd13419bda82e9fa41a16
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Property/ReadOnlyPropertyAttribute.cs
+++ b/Assets/Scripts/Property/ReadOnlyPropertyAttribute.cs
@@ -1,0 +1,6 @@
+using UnityEngine;
+
+/// <summary>
+/// Disallows editing of this property in the Inspector.
+/// </summary>
+public class ReadOnlyPropertyAttribute : PropertyAttribute {}

--- a/Assets/Scripts/Property/ReadOnlyPropertyAttribute.cs.meta
+++ b/Assets/Scripts/Property/ReadOnlyPropertyAttribute.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 820987ead779772469b975cb4c9f3ad9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -44,6 +44,18 @@
     "com.unity.modules.video": "1.0.0",
     "com.unity.modules.vr": "1.0.0",
     "com.unity.modules.wind": "1.0.0",
-    "com.unity.modules.xr": "1.0.0"
-  }
+    "com.unity.modules.xr": "1.0.0",
+    "com.johannesmp.unityscenereference": "1.1.1"
+  },
+  "scopedRegistries": [
+    {
+      "name": "package.openupm.com",
+      "url": "https://package.openupm.com",
+      "scopes": [
+        "com.eflatun.scenereference",
+        "com.johannesmp.unityscenereference",
+        "com.openupm"
+      ]
+    }
+  ]
 }

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -1,5 +1,12 @@
 {
   "dependencies": {
+    "com.johannesmp.unityscenereference": {
+      "version": "1.1.1",
+      "depth": 0,
+      "source": "registry",
+      "dependencies": {},
+      "url": "https://package.openupm.com"
+    },
     "com.unity.2d.sprite": {
       "version": "1.0.0",
       "depth": 0,

--- a/ProjectSettings/PackageManagerSettings.asset
+++ b/ProjectSettings/PackageManagerSettings.asset
@@ -25,11 +25,20 @@ MonoBehaviour:
     m_Scopes: []
     m_IsDefault: 1
     m_Capabilities: 7
-  m_UserSelectedRegistryName: 
+  - m_Id: scoped:package.openupm.com
+    m_Name: package.openupm.com
+    m_Url: https://package.openupm.com
+    m_Scopes:
+    - com.eflatun.scenereference
+    - com.johannesmp.unityscenereference
+    - com.openupm
+    m_IsDefault: 0
+    m_Capabilities: 0
+  m_UserSelectedRegistryName: package.openupm.com
   m_UserAddingNewScopedRegistry: 0
   m_RegistryInfoDraft:
     m_Modified: 0
     m_ErrorMessage: 
-    m_UserModificationsInstanceId: -830
-    m_OriginalInstanceId: -832
+    m_UserModificationsInstanceId: -826
+    m_OriginalInstanceId: -828
   m_LoadAssets: 0

--- a/ProjectSettings/Packages/com.unity.probuilder/Settings.json
+++ b/ProjectSettings/Packages/com.unity.probuilder/Settings.json
@@ -47,6 +47,11 @@
                 "type": "System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
                 "key": "editor.autoRecalculateCollisions",
                 "value": "{\"m_Value\":false}"
+            },
+            {
+                "type": "System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
+                "key": "editor.toolbarIconGUI",
+                "value": "{\"m_Value\":false}"
             }
         ]
     }

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -3,7 +3,8 @@
 --- !u!78 &1
 TagManager:
   serializedVersion: 2
-  tags: []
+  tags:
+  - SpawnPoint
   layers:
   - Default
   - TransparentFX


### PR DESCRIPTION
SaveState system implemented as described under the linked issue. Not in use by default; scene load callbacks need to be replaced with calls to `SaveState#LoadScene()` under the current instance stored in `GameManager`, and that instance must be setup from the main menu (underway in #29).

Closes #89.