### PR TITLE
Fix compile errors preventing game build

### DIFF
--- a/Assets/Scripts/Ui/UI_Inventory/Inventory.cs
+++ b/Assets/Scripts/Ui/UI_Inventory/Inventory.cs
@@ -1,6 +1,5 @@
 using System.Collections;
 using System.Collections.Generic;
-using UnityEditor.Animations;
 using UnityEngine;
 using UnityEngine.UI;
 


### PR DESCRIPTION
Remove a using statement from `Inventory.cs` causing compiler errors.